### PR TITLE
Support duplicate items

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -33,7 +33,38 @@ function moveBox(item) {
 	move.style.display = 'block';
 
 	var name = move.querySelector('.item-name')
-	name.innerHTML = _items[item.dataset.index].name;
+	var moveItem = _items[item.dataset.index];
+
+    if (moveItem.primStat) {
+		if (moveItem.primStat.statHash === 3897883278) {
+			// This item has defense stats, so lets pull some useful armor stats
+			var light      = moveItem.stats[0].value;
+			var intellect  = moveItem.stats[1].value;
+			var discipline = moveItem.stats[2].value;
+			var strength   = moveItem.stats[3].value;
+
+			name.innerHTML = moveItem.name + ' L: ' + light + ' I: ' + intellect + ' D: ' + discipline + ' S:' + strength;
+		} else if (moveItem.primStat.statHash === 368428387) {
+			// This item has attack stats, so lets pull some useful weapon stats
+			var attack = moveItem.primStat.value;
+			var damage = 'Kinetic';
+
+			if (moveItem.dmgType === 2) {
+				damage = 'Arc';
+			} else if (moveItem.dmgType === 3) {
+				damage = 'Solar';
+			} else if (moveItem.dmgType === 4) {
+				damage = 'Void';
+			}
+
+			name.innerHTML = moveItem.name + ' A: ' + attack + ' ' + damage + ' damage';
+		} else {
+			name.innerHTML = _items[item.dataset.index].name;	
+		} 
+    } else {
+		name.innerHTML = _items[item.dataset.index].name;
+	}
+
 	// switch(_items[item.dataset.index].tier) {
 	// 	TODO: be fancy and color the item name background the color of the item
 	// }
@@ -494,8 +525,11 @@ function appendItems(owner, defs, items) {
 			equipped:  item.isEquipped,
 			equipment: item.isEquipment,
 			complete:  item.isGridComplete,
-			amount:    item.stackSize
-		})
+			amount:    item.stackSize,
+			primStat:  item.primaryStat,
+			stats:     item.stats,
+			dmgType:   item.damageType
+		});
 	}
 
 	tryPageLoad();

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -383,7 +383,6 @@ function buildItems() {
 		if(_items[itemId].equipped) {
 			_storage[_items[itemId].owner].elements.equipped.querySelector('.sort-' + _items[itemId].type).appendChild(itemBox);
 		} else {
-			console.log(_items[itemId]);
 			_storage[_items[itemId].owner].elements.item.querySelector('.item-' + _items[itemId].sort + ' .sort-' + _items[itemId].type).appendChild(itemBox);
 		}
 	}


### PR DESCRIPTION
In it's current state, DIM does not properly handle the case where a character possesses multiple instances of the same item (for example, multiple pairs of raid boots).  Right now, the app is looping through the definitions dataset (of which there is only one entry per item) and joining that data against the actual bucket items.  It should actually be doing the reverse, so that each instance of an item is represented, with data common to all instances of a particular item being pulled from the corresponding definition.  I've made changes to correct this behavior and allow for all items (including duplicates) to be seen in the app.

While doing this, I realized it would now be very confusing to see several instances of the same item without knowing anything about their stats (damage type/attack rating for weapons, light level/intellect/discipline/strength for armor).  To alleviate some of that confusion, this PR also adds those simple stats to the Title bar of the move box when a user clicks on a particular item.  It's not very pretty, but it conveys the necessary information until a better solution is available.

The only remaining issue is that the UI sometimes moves the incorrect item when a user moves something via the move box.  For example, if you have two pairs of raid boots on your Warlock, one equipped and one not, and you select the unequipped pair of boots and move it to another character, the UI actually removes the *equipped* pair of boots from the screen.  Behind the scenes, the proper item gets moved, but a refresh is required to return the app to an accurate state.  This is probably due to the fact that all UI elements are associated with an itemHash instead of an itemInstanceId, so the move function doesn't know which one to pick.  I should have some time to look into that tomorrow.

Let me know what you think about the changes and if think any modifications need to be made before they are merged.