### PR TITLE
Fix ui issues with duplicates

### DIFF
--- a/scripts/loadout.js
+++ b/scripts/loadout.js
@@ -100,7 +100,7 @@ function loadout() {
   this.add = function(item) {
     if(item.type === 'Miscellaneous') return;
 
-    var node = document.querySelector('[data-name="' + item.name + '"]').cloneNode(true);
+    var node = document.querySelector('[data-instance-id="' + item.id + '"]').cloneNode(true);
     node.querySelector('img').draggable=false;
 
     var slot = _contents.querySelector('.loadout-' + item.type);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -156,11 +156,11 @@ function moveItem(item, destination, amount, callback) {
 function manageItemClick(item, data) {
 	if(data.type === 'equip') {
 		document.querySelector('.items[data-character="' + data.character + '"][data-type="equip"] .sort-' + item.type).appendChild(
-			document.querySelector('[data-name="' + item.name + '"]'));
+			document.querySelector('[data-instance-id="' + item.id + '"]'));
 		item.equipped = true;
 	} else {
 		document.querySelector('.items[data-character="' + data.character + '"] .item-' + item.sort + ' .sort-' + item.type	).appendChild(
-			document.querySelector('[data-name="' + item.name + '"]'));
+			document.querySelector('[data-instance-id="' + item.id + '"]'));
 		item.equipped = false;
 	}
 }
@@ -399,6 +399,7 @@ function buildItems() {
 		if(_items[itemId].complete) itemBox.className += ' complete';
 		itemBox.dataset.index = itemId;
 		itemBox.dataset.name = _items[itemId].name;
+		itemBox.dataset.instanceId = _items[itemId].id;
 		img.addEventListener('dragstart', function(e) {
 			_transfer = this.parentNode;
 		});

--- a/style.css
+++ b/style.css
@@ -36,10 +36,15 @@ body {
     font-size: 15px;
     font-weight: 500;
     color: rgba(245,245,245,.6);
-    width: 390px;
+    width: 260px;
 }
 .title .icon { width: 30px }
-.storage { margin-bottom: 100px; }
+.storage {
+  margin-top: 10px;
+  max-width: 260px;
+  float: left;
+  margin-right: 1em;
+}
 .item {
     position: relative;
     display: inline-block;
@@ -65,10 +70,10 @@ body {
 .character-box {
     position: relative;
     display: inline-block;
-    width: 281px;
+    width: 165px;
     height: 43px;
-    padding: 0 0 0 55px;
-    margin: 5px 5px 5px 0;
+    padding: 0 0 0 50px;
+    margin: 5px 0;
     opacity: 1;
     background: rgba(30,36,43,.5);
     color: #f5f5f5;
@@ -116,7 +121,7 @@ body {
     color: rgba(245,245,245,.6);
     vertical-align: top;
     text-align: center;
-    margin: 5px 0 5px 5px;
+    margin: 5px 0;
     line-height: 39px;
     padding: 0;
     cursor: pointer;
@@ -128,9 +133,9 @@ body {
     border-bottom: 2px solid rgba(245,245,245,.6);
     color: rgba(245,245,245,.6);
     margin-bottom: 10px;
-    width: 391px;
+    width: 260px;
     position: absolute;
-    left: -352px;
+    left: -220px;
     z-index: 2;
     cursor: pointer;
 }


### PR DESCRIPTION
When getting a handle on the DOM elements for items, the current code is using the item name, which is ambiguous if there are duplicates of that item.  This leads to the UI moving the wrong item boxes around and adding the wrong item boxes to loadouts.  Changing this to find the item based on its itemInstanceId, so the correct item box is appended during the move.