### PR TITLE
Fixing the drop destination when dragging and dropping items

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -247,10 +247,10 @@ function manageItem(e) {
 	moveItem(item, destination.dataset, amount, function() {
 		// move the item to the right spot once done.
 		if(_items[_transfer.dataset.index] === amount) {
-			destination.querySelector('.sort-' + item.type).appendChild(_transfer);
+			destination.querySelector('.item-' + item.sort + ' .sort-' + item.type).appendChild(_transfer);
 		} else {
 			// TODO: partial stack move, so copy the item...
-			destination.querySelector('.sort-' + item.type).appendChild(_transfer);
+			destination.querySelector('.item-' + item.sort + ' .sort-' + item.type).appendChild(_transfer);
 		}
 	});
 


### PR DESCRIPTION
It was driving me nuts that I would drag a piece of armor to another character and it would get added to the Weapons section.  I was going to wait for the Angular port to see if this was fixed, but couldn't take it anymore, so here is a quick fix in the meantime.

Basically, the current querySelector is ambiguous due to all sections containing all sort spans in the HTML.  This is a quick fix to find the correct sort span within the correct section, but in the long run, the HTML should probably be cleaned up.