### PR TITLE
Issue #116, make Mats and Consumables 4-column

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -1105,3 +1105,9 @@ button.toast-close-button {
   vertical-align: text-top;
   margin-top: -2px;
 }
+
+/** Issue #116, make Mats and Consumables 4-column **/
+.section.general .sort-consumable .unequipped,
+.section.general .sort-material .unequipped {
+  width: 208px;
+}


### PR DESCRIPTION
Addresses Issue #116 
--
Add CSS to make consumables and materials take a 4-column layout instead of 3