### PR TITLE
Issue #94, weapon type filters

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -276,6 +276,13 @@
         // }
 
         var itemType = getItemType(itemDef.itemTypeName, itemDef.itemName);
+        var specificType = null;
+
+        if(itemType !== null && itemType.hasOwnProperty('general'))
+        {
+          specificType = itemType.specific;
+          itemType = itemType.general;
+        }
 
         if (!itemType) {
           return;
@@ -316,7 +323,8 @@
           classType: itemDef.classType,
           /* 0: titan, 1: hunter, 2: warlock, 3: any */
           dmg: dmgName,
-          visible: true
+          visible: true,
+          specificType: specificType
         };
 
         if (item.itemHash === 2809229973) { // Necrochasm
@@ -388,17 +396,21 @@
       if (name.indexOf("Marks") != -1) {
         return null;
       }
+      var _ret = {
+          general: null,
+          specific: type.toLowerCase().replace(/\s/g, '')
+      };
 
       if (["Pulse Rifle", "Scout Rifle", "Hand Cannon", "Auto Rifle", "Primary Weapon Engram"].indexOf(type) != -1)
-        return 'Primary';
+        _ret.general = 'Primary';
       if (["Sniper Rifle", "Shotgun", "Fusion Rifle", "Special Weapon Engram"].indexOf(type) != -1) {
         // detect special case items that are actually primary weapons.
         if (["Vex Mythoclast", "Universal Remote", "No Land Beyond"].indexOf(name) != -1)
-          return 'Primary';
-        return 'Special';
+          _ret.general = 'Primary';
+        _ret.general = 'Special';
       }
       if (["Rocket Launcher", "Machine Gun", "Heavy Weapon Engram"].indexOf(type) != -1)
-        return 'Heavy';
+        _ret.general = 'Heavy';
       if (["Titan Mark", "Hunter Cloak", "Warlock Bond", "Class Item Engram"].indexOf(type) != -1)
         return 'ClassItem';
       if (["Gauntlet Engram"].indexOf(type) != -1)
@@ -416,6 +428,9 @@
       }
       if (["Armor Shader", "Emblem", "Ghost Shell", "Ship", "Vehicle", "Consumable", "Material"].indexOf(type) != -1)
         return type.split(' ')[0];
+
+      if(_ret.general !== null)
+        return _ret;
 
       return null;
     }

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -63,6 +63,8 @@
               special = 'classType';
             } else if (['dupe', 'duplicate'].indexOf(filterResult) >= 0) {
               special = 'dupe';
+            } else if (!!~["pulserifle","scoutrifle","handcannon","autorifle","primaryweaponengram","sniperrifle","shotgun","fusionrifle","specialweaponengram","rocketlauncher","machinegun","heavyweaponengram"].indexOf(filterResult)) {
+              special = 'weapontype';
             }
 
             tempFns.push(filterGenerator(filterResult, special));
@@ -199,6 +201,13 @@
               }
 
               return (item.classType !== value);
+            };
+            break;
+          }
+        case 'weapontype':
+          {
+            result = function(p, item) {
+              return p.toLowerCase().replace(/\s/g, '') !== item.specificType;
             };
             break;
           }

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -105,6 +105,23 @@
         <span>is:hunter</span>
         <span>is:warlock</span>
       </td>
-      <td>Shows items based on their class affinty.</td>
-    </tr>
+	  <td>Shows items based on their class affinty.</td>
+  </tr>
+  <tr>
+    <td>
+      <span>is:pulserifle</span>
+      <span>is:scoutrifle</span>
+      <span>is:handcannon</span>
+      <span>is:autorifle</span>
+      <span>is:primaryweaponengram</span>
+      <span>is:sniperrifle</span>
+      <span>is:shotgun</span>
+      <span>is:fusionrifle</span>
+      <span>is:specialweaponengram</span>
+      <span>is:rocketlauncher</span>
+      <span>is:machinegun</span>
+      <span>is:heavyweaponengram</span>
+    </td>
+    <td>Shows weapons based on their weapon type.</td>
+  </tr>
   </table>


### PR DESCRIPTION
Issue #94 
--

Weapons can now be filtered by the following types:

* is:pulserifle
* is:scoutrifle
* is:handcannon
* is:autorifle
* is:primaryweaponengram
* is:sniperrifle
* is:shotgun
* is:fusionrifle
* is:specialweaponengram
* is:rocketlauncher
* is:machinegun
* is:heavyweaponengram

*NB* as before, "sidearm" is not included until we know more