### PR TITLE
Line up vault section headers with guardian inventory headers.

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -54,9 +54,9 @@
       };
 
       var setHeight = function(query) {
-        var height = _.reduce(document.querySelectorAll(query), fn, 0);
-
         var style = document.querySelectorAll('style[id=' + ((query.replace(/\./g, '')).replace(/\s/g, '')) + ']');
+        if (style.length > 0) style[0].innerHTML = '';
+        var height = _.reduce(document.querySelectorAll(query), fn, 0);
 
         if (style.length > 0) {
           style = style[0];
@@ -68,7 +68,6 @@
         }
 
         style.innerHTML = query + ' { min-height: ' + (height) + 'px; }';
-        console.log('height set for ' + query);
       };
 
       setHeight('.guardian .sub-section.sort-class');

--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -42,15 +42,12 @@
       }
 
       var fn = function(memo, section) {
-        var childHeight = 0;
+        var sectionHeight = 0;
 
-        _.each(section.children, function(child) {
-          var t = outerHeight(child);
-          childHeight = (childHeight > t) ? childHeight : t;
-        });
+        sectionHeight = outerHeight(section);
 
-        if (childHeight > memo) {
-          memo = childHeight;
+        if (sectionHeight > memo) {
+          memo = sectionHeight;
         }
 
         return memo;
@@ -71,6 +68,7 @@
         }
 
         style.innerHTML = query + ' { min-height: ' + (height) + 'px; }';
+        console.log('height set for ' + query);
       };
 
       setHeight('.guardian .sub-section.sort-class');
@@ -89,8 +87,9 @@
       setHeight('.guardian .sub-section.sort-vehicle');
       setHeight('.guardian .sub-section.sort-consumable');
       setHeight('.guardian .sub-section.sort-material');
-      setHeight('.guardian .weapons');
-      setHeight('.guardian .armor');
+      setHeight('.section.weapons');
+      setHeight('.section.armor');
+      setHeight('.section.general');
     }
 
     function getStores(getFromBungie) {


### PR DESCRIPTION
Before:
![screenshot 2015-05-15 16 36 30](https://cloud.githubusercontent.com/assets/422381/7662336/b7e31c32-fb20-11e4-9bae-8adb425c0297.png)
After:
![screenshot 2015-05-15 16 36 01](https://cloud.githubusercontent.com/assets/422381/7662338/ba8f0c16-fb20-11e4-9bdf-15c7e9a8fb07.png)
