### PR TITLE
add tooltips to loadout items

### DIFF
--- a/app/scripts/loadout/dimLoadout.directive.js
+++ b/app/scripts/loadout/dimLoadout.directive.js
@@ -35,7 +35,7 @@
         '      <span id="loadout-contents">',
         '        <span ng-repeat="value in vm.types" class="loadout-{{ value }}">',
         '          <div ng-repeat="item in vm.loadout.items[value]" ng-click="vm.equip(item)" id="loadout-item-{{:: $id }}" class="item" ng-class="{ \'complete\': item.complete}">',
-        '            <img ng-src="{{ item.icon }}">',
+        '            <img ng-src="{{ item.icon }}" title="{{ item.primStat.value }} {{ item.name }}">',
         '            <div class="counter" ng-if="item.amount > 1">{{ item.amount }}</div>',
         '            <div class="close" ng-click="vm.remove(item); vm.form.name.$rollbackViewValue(); $event.stopPropagation();"></div>',
         '            <div class="equipped" ng-show="item.equipped"></div>',


### PR DESCRIPTION
trivial patch to show the tooltips from the main view to the loadout pane (too many similar weapons since HOW).  I'm a C/middleware developer but the patch worked in my sandbox.  Thanks for the great software.