### PR TITLE
Better filter cleanup, is:stackable, is:<weapontype>

### DIFF
--- a/app/scripts/services/dimStoreService.factory.js
+++ b/app/scripts/services/dimStoreService.factory.js
@@ -22,8 +22,6 @@
       return _index++;
     }
 
-
-
     function setHeights() {
       function outerHeight(el) {
         //var height = el.offsetHeight;
@@ -277,9 +275,15 @@
         // }
 
         var itemType = getItemType(itemDef.itemTypeName, itemDef.itemName);
+        var weaponClass = null;
 
         if (!itemType) {
           return;
+        }
+
+        if (itemType.hasOwnProperty('general') && itemType.general !== '') {
+          weaponClass = itemType.weaponClass;
+          itemType = itemType.general;
         }
 
         var itemSort = sortItem(itemDef.itemTypeName);
@@ -410,7 +414,8 @@
           hasAscendNode: false,
           ascended: false,
           lockable: item.lockable,
-          locked: item.locked
+          locked: item.locked,
+          weaponClass: weaponClass || ''
         };
 
         if (item.itemHash === 2809229973) { // Necrochasm
@@ -429,7 +434,7 @@
         var talents = talentDefs.data[item.talentGridHash];
 
         var ascendNode = (talents) ? _.filter(talents.nodes, function(node) {
-          return _.some(node.steps, function(step) { return step.nodeStepName === 'Ascend' });
+          return _.some(node.steps, function(step) { return step.nodeStepName === 'Ascend'; });
         }) : undefined;
 
 
@@ -525,16 +530,22 @@
         return null;
       }
 
+      // Used to find a "weaponClass" type to send back
+      var typeObj = {
+        general: '',
+        weaponClass: type.toLowerCase().replace(/\s/g, '')
+      };
+
       if (["Pulse Rifle", "Scout Rifle", "Hand Cannon", "Auto Rifle", "Primary Weapon Engram"].indexOf(type) != -1)
-        return 'Primary';
+        typeObj.general = 'Primary';
       if (["Sniper Rifle", "Shotgun", "Fusion Rifle", "Sidearm", "Special Weapon Engram"].indexOf(type) != -1) {
         // detect special case items that are actually primary weapons.
         if (["Vex Mythoclast", "Universal Remote", "No Land Beyond"].indexOf(name) != -1)
-          return 'Primary';
-        return 'Special';
+          typeObj.general = 'Primary';
+        typeObj.general = 'Special';
       }
       if (["Rocket Launcher", "Machine Gun", "Heavy Weapon Engram"].indexOf(type) != -1)
-        return 'Heavy';
+        typeObj.general = 'Heavy';
       if (["Titan Mark", "Hunter Cloak", "Warlock Bond", "Class Item Engram"].indexOf(type) != -1)
         return 'ClassItem';
       if (["Gauntlet Engram"].indexOf(type) != -1)
@@ -549,6 +560,10 @@
         if (["Vanguard Marks", "Crucible Marks"].indexOf(name) != -1)
           return '';
         return 'Material';
+      }
+
+      if(typeObj.general !== '') {
+        return typeObj;
       }
 
       if (["Public Event Completed"].indexOf(name) != -1) {

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -110,7 +110,8 @@
       'ascended':     ['ascended', 'assended', 'asscended'],
       'locked':       ['locked'],
       'unlocked':     ['unlocked'],
-      'stackable':    ['stackable']
+      'stackable':    ['stackable'],
+      'weaponclass':  ["pulserifle", "scoutrifle", "handcannon", "autorifle", "primaryweaponengram", "sniperrifle", "shotgun", "fusionrifle", "specialweaponengram", "rocketlauncher", "machinegun", "heavyweaponengram", "sidearm"]
     };
 
     // Cache for searches against filterTrans. Somewhat noticebly speeds up the lookup on my older Mac, YMMV. Helps
@@ -207,6 +208,9 @@
       },
       'stackable': function(predicate, item) {
         return item.maxStackSize > 1;
+      },
+      'weaponclass': function(predicate, item) {
+        return predicate.toLowerCase().replace(/\s/g, '') == item.weaponClass;
       }
     };
   }

--- a/app/scripts/shell/dimSearchFilter.directive.js
+++ b/app/scripts/shell/dimSearchFilter.directive.js
@@ -109,7 +109,8 @@
       'unascended':   ['unascended', 'unassended', 'unasscended'],
       'ascended':     ['ascended', 'assended', 'asscended'],
       'locked':       ['locked'],
-      'unlocked':     ['unlocked']
+      'unlocked':     ['unlocked'],
+      'stackable':    ['stackable']
     };
 
     // Cache for searches against filterTrans. Somewhat noticebly speeds up the lookup on my older Mac, YMMV. Helps
@@ -203,6 +204,9 @@
         }
 
         return (item.classType == value);
+      },
+      'stackable': function(predicate, item) {
+        return item.maxStackSize > 1;
       }
     };
   }

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -128,4 +128,10 @@
       </td>
       <td>Shows items based on their locked status.</td>
     </tr>
+    <tr>
+      <td>
+        <span>is:stackable</span>
+      </td>
+      <td>Shows items that can stack (ammo synths, strange coin, etc)</td>
+    </tr>
   </table>

--- a/app/views/filters.html
+++ b/app/views/filters.html
@@ -134,4 +134,22 @@
       </td>
       <td>Shows items that can stack (ammo synths, strange coin, etc)</td>
     </tr>
+    <tr>
+      <td>
+        <span>is:pulserifle</span>
+        <span>is:scoutrifle</span>
+        <span>is:handcannon</span>
+        <span>is:autorifle</span>
+        <span>is:primaryweaponengram</span>
+        <span>is:sniperrifle</span>
+        <span>is:shotgun</span>
+        <span>is:fusionrifle</span>
+        <span>is:sidearm</span>
+        <span>is:specialweaponengram</span>
+        <span>is:rocketlauncher</span>
+        <span>is:machinegun</span>
+        <span>is:heavyweaponengram</span>
+      </td>
+      <td>Shows weapons based on their weapon type.</td>
+    </tr>
   </table>


### PR DESCRIPTION
Much Improved Filter Cleanup

* Moved filter sets (elemental => arc, solar, void) into easier to read object
* Add caching to reduce the overhead of `for` loop for aforementioned object
* Moved filter functions into easier-to-maintain object
* Removed half of the filtering loop - only need to `.each` once if `item.visible = filterFn(item)`
* Reversed logic on most filter functions to make more sense for devs (no more returning false to signify a "match" for the filter)
* Removed commented `outerHeight` method - it's in the repo, just cleaning up